### PR TITLE
Changed metric to calculate memory consumption

### DIFF
--- a/hack/examples/alertpolicy_mixed.yaml
+++ b/hack/examples/alertpolicy_mixed.yaml
@@ -9,7 +9,7 @@ spec:
   incident_preference: "per_policy"
   nrqlConditions:
     - name: High container memory usage
-      query: "SELECT sum(memoryUsedBytes/memoryLimitBytes)*100 FROM K8sContainerSample FACET podName"
+      query: "SELECT sum(memoryWorkingSetBytes/memoryLimitBytes)*100 FROM K8sContainerSample FACET podName"
       sinceMinutes: 15
       alertThreshold:
         timeFunction: any

--- a/hack/examples/alertpolicy_nrql.yaml
+++ b/hack/examples/alertpolicy_nrql.yaml
@@ -9,7 +9,7 @@ spec:
   incident_preference: "per_policy"
   nrqlConditions:
     - name: High container memory usage
-      query: "SELECT sum(memoryUsedBytes/memoryLimitBytes)*100 FROM K8sContainerSample FACET podName"
+      query: "SELECT sum(memoryWorkingSetBytes/memoryLimitBytes)*100 FROM K8sContainerSample FACET podName"
       sinceMinutes: 15
       alertThreshold:
         timeFunction: any

--- a/hack/examples/personio_alert.yaml
+++ b/hack/examples/personio_alert.yaml
@@ -85,7 +85,7 @@ spec:
       valueFunction: single_value
 
     - name: High memory usage
-      query: "SELECT average(memoryUsedBytes/memoryLimitBytes) FROM K8sContainerSample WHERE deploymentName = '{{.Release.Name}}'"
+      query: "SELECT average(memoryWorkingSetBytes/memoryLimitBytes) FROM K8sContainerSample WHERE deploymentName = '{{.Release.Name}}'"
       sinceMinutes: 3
       alertThreshold:
         operator: above

--- a/hack/examples/personio_dashboard.yaml
+++ b/hack/examples/personio_dashboard.yaml
@@ -98,7 +98,7 @@ spec:
   - title: Average Memory utilization
     visualization: faceted_line_chart
     data:
-      nrql: "SELECT average(memoryUsedBytes/memoryLimitBytes) * 100 FROM K8sContainerSample WHERE deploymentName = '{{ .Release.Name }}' FACET podName TIMESERIES"
+      nrql: "SELECT average(memoryWorkingSetBytes/memoryLimitBytes) * 100 FROM K8sContainerSample WHERE deploymentName = '{{ .Release.Name }}' FACET podName TIMESERIES"
     layout:
       row: 2
       column: 3


### PR DESCRIPTION
- According to this discussion (https://discuss.newrelic.com/t/mismatch-between-k8scontainersample-memoryusedbytes-and-actual-memory-usage-in-container/64508/8) the most accurate metric to calculate memory consumption is not memoryUsedBytes but memoryWorkingSetBytes. The first one includes some cached memory that can be freed up, the later is the used for kctl to determine resource exhaustion.